### PR TITLE
Reception_invitation 웹소켓 메시지 처리

### DIFF
--- a/user_management/consumers.py
+++ b/user_management/consumers.py
@@ -51,6 +51,9 @@ class NotificationConsumer(AsyncWebsocketConsumer):
             await self.broadcast_message(notification_type, content)
         else:
             self.send(json.dumps({'error': 'Invalid notification type'}))
+            
+    async def reception_invitation(self, event):
+        await self.send_json(event)
 
     # 메시지를 그룹에 브로드캐스트
     async def broadcast_message(self, notification_type, content):
@@ -69,3 +72,11 @@ class NotificationConsumer(AsyncWebsocketConsumer):
             'notification_type': event['notification_type'],
             'content': event['content']
         }))
+        
+    async def send_json(self, message):
+        try:
+            json_message = json.dumps(message)
+            await self.send(text_data=json_message)
+        except (TypeError, ValueError) as e:
+            error_message = {"type": "error", "message":"Invalid json format."}
+            await self.send(text_data=json.dumps(error_message))

--- a/user_management/redis_utils.py
+++ b/user_management/redis_utils.py
@@ -3,12 +3,16 @@ import redis.asyncio as redis
 redis_client = redis.Redis(host='localhost', port=6379, db=0)
 
 ONLINE_USERS_KEY = 'online_users'
-USER_CHANNELS_KEY_PREFIX = 'user_channels:'
+USER_CHANNELS_KEY = 'user_channels'
 
 async def add_user_to_online_users(user_id, channel_name):
     await redis_client.sadd(ONLINE_USERS_KEY, user_id)
-    await redis_client.hset("user_channels", user_id, channel_name)
+    await redis_client.hset(USER_CHANNELS_KEY, user_id, channel_name)
+    
+async def get_channel_name(user_id):
+    channel_name = await redis_client.hget(USER_CHANNELS_KEY, user_id)
+    return channel_name.decode("utf-8") if channel_name else None
 
 async def remove_user_from_online_users(user_id):
     await redis_client.srem(ONLINE_USERS_KEY, user_id)
-    await redis_client.hdel("user_channels", user_id)
+    await redis_client.hdel(USER_CHANNELS_KEY, user_id)


### PR DESCRIPTION
## 주요 구현 사항

- NotificationConsumer에서 reception_invitation 메시지 처리

## 참고 사항
서버에서 `channel_name`으로 `send()`하면 해당 클라이언트 Consumer의 `receive()` 함수가 아닌 message의 type에 따른 함수가 호출됨. 이에 `reception_invitation()`함수를 만들고 단순히 사용자에게 메시지 전달하게끔 작성

