### PR TITLE
친구 요청 알림 전송

### DIFF
--- a/friend/views.py
+++ b/friend/views.py
@@ -4,13 +4,14 @@ from rest_framework import status
 from .services import send_friend_request, respond_to_friend_request, get_friends_list
 from rest_framework.exceptions import ValidationError, NotFound
 from drf_spectacular.utils import extend_schema
+from asgiref.sync import async_to_sync
 
 
 class SendFriendRequestView(APIView):
     def post(self, request):
         to_user_id = request.data.get('to_user_id')
         try:
-            send_friend_request(request.user_id, to_user_id)
+            async_to_sync(send_friend_request)(request.user_id, to_user_id)
             return Response({"message": "Friend request sent successfully"}, status=status.HTTP_201_CREATED)
         except ValidationError as e:
             return Response({"message": str(e)}, status=status.HTTP_400_BAD_REQUEST)

--- a/user_management/consumers.py
+++ b/user_management/consumers.py
@@ -55,6 +55,9 @@ class NotificationConsumer(AsyncWebsocketConsumer):
     async def reception_invitation(self, event):
         await self.send_json(event)
 
+    async def friend_request(self, event):
+        await self.send_json(event)
+
     # 메시지를 그룹에 브로드캐스트
     async def broadcast_message(self, notification_type, content):
         await self.channel_layer.group_send(

--- a/user_management/services.py
+++ b/user_management/services.py
@@ -7,6 +7,10 @@ from .models import EmailVerificationCode
 
 User = get_user_model()
 
+async def get_user_name(user_id):
+    user = await User.objects.aget(id=user_id)
+    return user.nickname
+
 def generate_verification_code(length=6):
     return ''.join(random.choices(string.ascii_uppercase + string.digits, k=length))
 


### PR DESCRIPTION
## 주요 구현 사항
- 친구 요청 시 `consumer`의 `friend_request` 메서드 호출을 통해 `to_user_id`의 채널에 알림 전송
- 비동기 함수인 `send_friend_request`에서 데이터베이스 쿼리에 비동기 처리 추가