### PR TITLE
에러 응답에서 중첩된 상태 코드를 올바르게 추출하도록 수정

### DIFF
--- a/config/response_builder.py
+++ b/config/response_builder.py
@@ -16,12 +16,12 @@ def response_error(errors):
     )
 
 def extract_status(errors):
-    for key, value in errors.items():
-        if key == "status":
-            if isinstance(value, ErrorDetail):
-                return str(value)
-            elif isinstance(value, list) and isinstance(value[0], ErrorDetail):
-                return str(value[0])
-        elif isinstance(value, dict):  # 중첩된 dict 처리
-            return extract_status(value)  # 재귀 호출
-    return None
+    if isinstance(errors, dict):
+        for key, value in errors.items():
+            if key == "status" and isinstance(value, str) and value.isdigit():
+                return int(value)
+            elif isinstance(value, dict):
+                nested_status = extract_status(value)
+                if nested_status:
+                    return nested_status
+    return status.HTTP_400_BAD_REQUEST


### PR DESCRIPTION
## 관련된 이슈 번호

- Closes #40 

## 주요 구현 사항

- `extract_status` 함수에서 중첩된 딕셔너리 구조를 처리할 수 있도록 개선
- `serializer.errors`에 포함된 상태 코드(예: `409 Conflict`)를 올바르게 추출
- 상태 코드를 찾지 못할 경우 기본값으로 `400 Bad Request` 반환
