### PR TITLE
User profile, Friend_request hotfix

### DIFF
--- a/config/error_type.py
+++ b/config/error_type.py
@@ -15,7 +15,7 @@ class ErrorType(Enum):
     INVALID_EMAIL_REQUEST = (status.HTTP_400_BAD_REQUEST, "The email sending request is invalid.")
 
     # common
-    FIELD_REQUIRED = (status.HTTP_400_BAD_REQUEST, "The field is required.")
+    FIELD_REQUIRED = (status.HTTP_400_BAD_REQUEST, "The nickname field is required.")
 
     # friend
     FRIEND_REQUEST_ALREADY_EXISTS = (status.HTTP_409_CONFLICT, "Friend request already exists or received.")

--- a/config/services.py
+++ b/config/services.py
@@ -1,5 +1,6 @@
 import aiohttp
 from config.settings import CHAT_SERVICE_URL
+from datetime import datetime
 
 # 채팅 서비스의 채팅방 생성 API 호출
 async def get_chatroom(user1_id, user2_id, token):
@@ -25,3 +26,8 @@ async def delete_chatroom(chatroom_id, token):
             if response.status == 204: # 채팅방 삭제 성공
                 return True
             return None
+        
+def format_datetime(dt):
+    if isinstance(dt, datetime):
+        return dt.strftime('%Y-%m-%d %H:%M:%S')
+    return dt

--- a/friend/services.py
+++ b/friend/services.py
@@ -1,6 +1,6 @@
 from django.contrib.auth import get_user_model
 from django.db.models import Q
-from config.services import get_chatroom, delete_chatroom
+from config.services import get_chatroom, delete_chatroom, format_datetime
 from channels.layers import get_channel_layer
 from user_management.redis_utils import get_channel_name
 from asgiref.sync import async_to_sync
@@ -41,14 +41,14 @@ class FriendService:
         if not channel_name:
             return
 
-        sender = await UserService.get_user_name(from_user_id)
-        created_at_str = created_at.isoformat()
+        from_user = await UserService.get_user_name(from_user_id)
+        created_at_str = format_datetime(created_at)
         await channel_layer.send(
             channel_name,
             {
                 "type": "friend.request",
-                "friend_request_id": friend_request_id,
-                "sender": sender,
+                "id": friend_request_id,
+                "from_user": from_user,
                 "created_at": created_at_str
             }
         )

--- a/user_management/urls.py
+++ b/user_management/urls.py
@@ -9,6 +9,7 @@ from .views import (
     UserProfileView,
     SendEmailView,
     VerifyCodeView,
+    MyProfileView,
 )
 
 urlpatterns = [
@@ -16,6 +17,7 @@ urlpatterns = [
     path('register/email-check/', EmailCheckAndSendCodeView.as_view(), name='email-check'),
     path('register/complete/', UserRegisterView.as_view(), name='register-complete'),
     path('login/', UserLoginView.as_view(), name='login'),
+    path('profile/', MyProfileView.as_view(), name='my-profile'),
     path('profile/<int:user_id>/', UserProfileView.as_view(), name='user-profile'),
     path('send-email/', SendEmailView.as_view(), name='send-email'),
     path('2fa/', VerifyCodeView.as_view(), name='2fa')

--- a/user_management/views.py
+++ b/user_management/views.py
@@ -73,19 +73,26 @@ class VerifyCodeView(APIView):
         return response_errors(serializer.errors)
 
 
+class MyProfileView(APIView):
+    def get(self, request):
+        user = get_object_or_404(User, id=request.user_id)
+        serializer = UserProfileSerializer(user)
+        return response_ok(serializer.data)
+
+    def put(self, request):
+        user = get_object_or_404(User, id=request.user_id)
+        serializer = UserProfileSerializer(user, data=request.data, partial=True, context={'request': request})
+        if serializer.is_valid():
+            serializer.save()
+            return response_ok(serializer.data)
+        return response_errors(errors=serializer.errors) 
+
+
 class UserProfileView(APIView):
     def get(self, request, user_id):
         user = get_object_or_404(User, id=user_id)
         serializer = UserProfileSerializer(user)
         return response_ok(serializer.data)
-
-    def put(self, request, user_id):
-        user = get_object_or_404(User, id=user_id)
-        serializer = UserProfileSerializer(user, data=request.data, partial=True, context={'request': request})
-        if serializer.is_valid():
-            serializer.save()
-            return response_ok(serializer.data)
-        return response_errors(errors=serializer.errors)
     
 
 class SendEmailView(APIView):


### PR DESCRIPTION
## 주요 구현 사항

### UserProile endpoint 분리
- 자기 자신에 대한 조회/수정: `'profile/'`
- 다른 유저 프로필 조회: `'profile/<int:user_id>/'`

### Friend Request시 웹소켓 알림 메시지 형식을 Model의 필드 네임과 통일
- 예시
```json
{
    "type": "friend.request",
    "id": 5,
    "from_user": "test",
    "created_at": "2024-12-28 16:46:43"
}
```