### PR TITLE
Friend list with detail

### DIFF
--- a/config/middleware.py
+++ b/config/middleware.py
@@ -10,13 +10,14 @@ EXCLUDED_PATHS = [
             '/api/user/register/nickname-check/',
             '/api/user/register/complete/',
             '/api/user/login/',
-            '/api/user/2fa/'
+            '/api/user/2fa/',
+            '/media/avatars/',
 ]
 
 # HTTP Middleware
 class CustomHttpMiddleware(MiddlewareMixin):
     def process_request(self, request):
-        if request.path in EXCLUDED_PATHS:  # 제외된 경로 처리
+        if any(request.path.startswith(path) for path in EXCLUDED_PATHS):  # 제외된 경로 처리
             return
 
         token_line = request.headers.get("Authorization")

--- a/config/urls.py
+++ b/config/urls.py
@@ -1,5 +1,7 @@
 from django.urls import path, include
 from drf_spectacular.views import SpectacularAPIView, SpectacularRedocView, SpectacularSwaggerView
+from django.conf import settings
+from django.conf.urls.static import static
 
 urlpatterns = [
     path('api/schema/', SpectacularAPIView.as_view(), name='schema'),
@@ -8,3 +10,7 @@ urlpatterns = [
     path('api/user/', include('user_management.urls')),
     path('api/friend/', include('friend.urls')),
 ]
+
+# 개발 환경에서만 미디어 파일 서빙
+if settings.DEBUG:
+    urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/friend/views.py
+++ b/friend/views.py
@@ -60,10 +60,10 @@ class FriendListView(APIView):
         },
     )
     def get(self, request):
-        friends = FriendService.get_friends_list(request.user)
+        friends = FriendService.get_friends_list(request.user_id)
         if friends is None:
             return response_errors(errors=CustomValidationError(ErrorType.FRIENDS_LIST_UNAVAILABLE))
-        return response_ok(data=friends)
+        return response_ok(friends)
 
 
 class DeleteFriendView(APIView):

--- a/user_management/redis_utils.py
+++ b/user_management/redis_utils.py
@@ -12,7 +12,8 @@ async def add_user_to_online_users(user_id, channel_name):
     
 async def get_channel_name(user_id):
     channel_name = await redis_client.hget(USER_CHANNELS_KEY, user_id)
-    return channel_name.decode("utf-8") if channel_name else None
+    if channel_name:
+        return channel_name.decode("utf-8")
 
 async def remove_user_from_online_users(user_id):
     await redis_client.srem(ONLINE_USERS_KEY, user_id)

--- a/user_management/urls.py
+++ b/user_management/urls.py
@@ -1,6 +1,4 @@
 from django.urls import path
-from django.conf import settings
-from django.conf.urls.static import static
 from .views import (
     EmailCheckAndSendCodeView,
     NicknameCheckView,
@@ -22,7 +20,3 @@ urlpatterns = [
     path('send-email/', SendEmailView.as_view(), name='send-email'),
     path('2fa/', VerifyCodeView.as_view(), name='2fa')
 ]
-
-# 개발 환경에서만 미디어 파일 서빙
-if settings.DEBUG:
-    urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)


### PR DESCRIPTION
## 주요 구현 사항

- media url_patterns 설정 위치 변경: friend에서도 avatar를 서빙해서 user.urls->config.urls로 이동, middleware의 인증 경로에서 제외하여 token없이도 이미지 가져와지게 수정
- friend_list에 필드 추가: `avatar` 추가, `chatroom_id` 추가, `is_online` 추가

## 리뷰어 참고 사항

### 응답예시
```json
{
    "message": [
        {
            "frend_id": 3,
            "nickname": "user3",
            "avatar": "/media/avatars/default.png",
            "chatroom_id": 2,
            "is_online": false
        }
    ]
}
```