### PR TITLE
Allowed hosts & install psycopg

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -27,7 +27,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 MEDIA_URL = '/media/'
 MEDIA_ROOT = BASE_DIR / 'media'
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ['api-gateway']
 
 
 # Application definition

--- a/config/settings.py
+++ b/config/settings.py
@@ -27,7 +27,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 MEDIA_URL = '/media/'
 MEDIA_ROOT = BASE_DIR / 'media'
 
-ALLOWED_HOSTS = ['api-gateway']
+ALLOWED_HOSTS = ['api-gateway', 'localhost']
 
 
 # Application definition

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,6 +33,7 @@ packaging==24.2
 pillow==11.0.0
 pluggy==1.5.0
 propcache==0.2.1
+psycopg==3.2.3
 pyasn1==0.6.1
 pyasn1_modules==0.4.1
 pycparser==2.22
@@ -46,7 +47,6 @@ referencing==0.35.1
 requests==2.32.3
 rpds-py==0.22.3
 service-identity==24.2.0
-setuptools==75.6.0
 sqlparse==0.5.2
 tomli==2.2.1
 Twisted==24.11.0


### PR DESCRIPTION
## 주요 구현 사항
- 전체 연결 중 필요한 패키지 설치
- allowed hosts 설정: api-gateway와 localhost의 요청만 허용하게