### PR TITLE
친구 요청 거절해도 재전송 가능하도록 수정

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -27,7 +27,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 MEDIA_URL = '/media/'
 MEDIA_ROOT = BASE_DIR / 'media'
 
-ALLOWED_HOSTS = ['api-gateway', 'localhost']
+# ALLOWED_HOSTS = ['api-gateway', 'localhost', '127.0.0.1']
 
 
 # Application definition

--- a/friend/services.py
+++ b/friend/services.py
@@ -112,7 +112,7 @@ class FriendService:
             friend_user = friendship.user1 if friendship.user2 == user else friendship.user2
             is_online = async_to_sync(get_channel_name)(friend_user.id) is not None
             friend_detail = {
-                "frend_id": friend_user.id,
+                "friend_id": friend_user.id,
                 "nickname": friend_user.nickname,
                 "avatar": friend_user.avatar.url,
                 "chatroom_id": friendship.chatroom_id,

--- a/friend/services.py
+++ b/friend/services.py
@@ -90,9 +90,8 @@ class FriendService:
                 friendship.save()
 
             elif action == "reject":
-                friend_request.status = "rejected"
-                friend_request.save()
-
+                friend_request.delete()                
+                
 
     @staticmethod
     def get_received_friend_requests(user_id):


### PR DESCRIPTION
## 주요 구현 사항
### 친구 요청 거절해도 다시 친구 요청 전송 가능하도록 수정
- 친구 요청 거절 시 데이터베이스에서 해당 레코드를 삭제
### `ALLOWED_HOSTS` 설정으로 인해 `MSA(Microservices Architecture)` 환경에서 서비스 간의 통신이 차단되는 문제 해결
- 추후 프로덕션 환경에서는 각 서비스의 도메인/IP를 명시적으로 추가하는 개선 필요