### PR TITLE
🐛 fix(auth): Handle CustomValidationError in login view

### DIFF
--- a/user_management/views.py
+++ b/user_management/views.py
@@ -50,7 +50,10 @@ class UserLoginView(APIView):
         if serializer.is_valid():
             email = serializer.validated_data['email']
             password = serializer.validated_data['password']
-            user = AuthService.authenticate_user(email, password)
+            try:
+                user = AuthService.authenticate_user(email, password)
+            except CustomValidationError as e:
+                return response_errors(errors=e)
             if user.is_2fa_enabled:
                 AuthService.process_email_verification_code(email)
                 return response_ok({


### PR DESCRIPTION
## Summary
- Fix login view returning 400 instead of 401 for invalid credentials
- Add try/except block to catch CustomValidationError from AuthService.authenticate_user()

## Test plan
- [x] Verify `test_login_invalid_credentials` passes with 401 status